### PR TITLE
ProgressBar 기능 구현

### DIFF
--- a/src/components/ProgressBar/ProgressBar.jsx
+++ b/src/components/ProgressBar/ProgressBar.jsx
@@ -1,4 +1,9 @@
-import React, { forwardRef, useImperativeHandle, useRef } from "react";
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 import "./ProgressBar.scss";
 import music1 from "../../music/music-1.mp3";
 import { useDispatch } from "react-redux";
@@ -6,7 +11,10 @@ import { playMusic, stopMusic } from "../../store/musicPlayerReducer";
 
 function ProgressBar(props, ref) {
   const audio = useRef();
+  const progressBar = useRef();
   const dispatch = useDispatch();
+  const [currentTime, setcurrentTime] = useState("00:00");
+  const [duration, setDuration] = useState("00:00");
 
   useImperativeHandle(ref, () => ({
     play: () => {
@@ -21,23 +29,47 @@ function ProgressBar(props, ref) {
     dispatch(playMusic());
   };
 
+  const getTime = (time) => {
+    const minute = `0${parseInt(time / 60, 10)}`;
+    const seconds = `0${parseInt(time % 60)}`;
+    return `${minute}:${seconds.slice(-2)}`;
+  };
+
+  const onClickProgress = (event) => {
+    const progressBarWidth = event.currentTarget.clientWidth;
+    const offsetX = event.nativeEvent.offsetX;
+    const duration = audio.current.duration;
+    audio.current.currentTime = (offsetX / progressBarWidth) * duration;
+  };
+
+  const onTimeUpdate = (event) => {
+    if (event.target.readyState === 0) return;
+    const currentTime = event.target.currentTime;
+    const duration = event.target.duration;
+    const progressBarWidth = (currentTime / duration) * 100;
+    progressBar.current.style.width = `${progressBarWidth}%`;
+    setcurrentTime(getTime(currentTime));
+    setDuration(getTime(duration));
+  };
+
   const onPause = () => {
     dispatch(stopMusic());
   };
   return (
-    <div className="progress-area">
-      <div className="progress-bar">
+    <div className="progress-area" onMouseDown={onClickProgress}>
+      <div className="progress-bar" ref={progressBar}>
         <audio
           autoPlay
           ref={audio}
           src={music1}
           onPlay={onPlay}
           onPause={onPause}
+          onTimeUpdate={onTimeUpdate}
         ></audio>
       </div>
       <div className="music-timer">
-        <span>00:00</span>
-        <span>00:00</span>
+        <span>{currentTime}</span>
+        <span>{duration}</span>
       </div>
     </div>
   );

--- a/src/components/ProgressBar/ProgressBar.scss
+++ b/src/components/ProgressBar/ProgressBar.scss
@@ -9,7 +9,7 @@
 
   .progress-bar {
     height: inherit;
-    width: 100%;
+    width: 0%;
     position: relative;
     border-radius: inherit;
     background: $blue;


### PR DESCRIPTION
* 음악이 재생됨과 동시에 현재 시간과 총 재생 시간을 좌우로 보여준다.  `onTimeUpdate`메소드를 작성해서 `audio`의 `source` 의 총 재생 시간과 현재 시간을 정의해서  현재 음악이 재생되는 시간을 구한뒤, 그만큼을 컴포넌트의 width 속성에 적용시킴

* 사용자가 `progressBar`의 구간중 원하는 곳을 클릭하면 해당 시간으로 Bar가 이동한다.

`.progress-bar`의 상위 요소인 `.progress-area`에 `onMouseDown` property 에 `onClickProgress`메서드를 추가. 
사용자가 클릭하는 순간 해당 위치를 offsetX로 가져온 뒤, 클릭한 곳의 시간을 현재 시간으로 재정의한다.

This Closes #9 