### PR TITLE
음량 조절 기능 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,12 +12,15 @@ function App() {
   const onPause = () => {
     audioRef.current.pause();
   };
+  const changeVolume = (volume) => {
+    audioRef.current.changeVolume(volume);
+  };
   return (
     <div className="App">
       <div className="container">
         <SongDetail />
         <ProgressBar ref={audioRef} />
-        <Controls play={onPlay} pause={onPause} />
+        <Controls play={onPlay} pause={onPause} changeVolume={changeVolume} />
         <PlayList />
       </div>
     </div>

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -10,7 +10,7 @@ import VolumeUp from "@mui/icons-material/VolumeUp";
 import "./Controls.scss";
 import { useSelector } from "react-redux";
 
-function Controls({ play, pause }) {
+function Controls({ play, pause, changeVolume }) {
   const playing = useSelector((state) => state.playing);
 
   const onClickPlay = () => {
@@ -20,6 +20,11 @@ function Controls({ play, pause }) {
   const onClickPause = () => {
     pause();
   };
+
+  const onChangeVolume = (event) => {
+    changeVolume(event.target.value);
+  };
+
   return (
     <div className="control-area">
       <QueueMusic sx={{ fontSize: 30, cursor: "pointer" }} />
@@ -43,6 +48,7 @@ function Controls({ play, pause }) {
           type="range"
           style={{ cursor: "pointer" }}
           defaultValue={1}
+          onChange={onChangeVolume}
           min="0"
           max="1"
           step="0.1"

--- a/src/components/ProgressBar/ProgressBar.jsx
+++ b/src/components/ProgressBar/ProgressBar.jsx
@@ -23,6 +23,9 @@ function ProgressBar(props, ref) {
     pause: () => {
       audio.current.pause();
     },
+    changeVolume: (volume) => {
+      audio.current.volume = volume;
+    },
   }));
 
   const onPlay = () => {


### PR DESCRIPTION
music player의 음량 조절 기능을 구현

* `ProgressBar`컴포넌트에서 `useImperativeHandle`에 audio의 volume 값을 파라미터로 하는 `changeVolume`을내보내줌

* `changeVolume`을 `app.js`에서 `Controls`컴포넌트의 `Props` 보냄

* `Controls`내부에서 음량을 나타내는 `input` 컴포넌트에 `onChange`로 `onChangeVolume`메서드를 추가함

* 이 때 `onChangeVolume`은 사용자가 원하는 음량의 위치를 클릭해서 변경된 수치를 event값의 파라미터로 두고 해당 `target.value`를 `Volume`값으로 변경하는 `changeVolume`을 호출하는 방식으로 정의함

This closes #11 