### PR TITLE
이전곡,다음곡 스킵 기능 구현

### DIFF
--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -8,11 +8,12 @@ import SkipNext from "@mui/icons-material/SkipNext";
 import VolumeUp from "@mui/icons-material/VolumeUp";
 
 import "./Controls.scss";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { nextMusic, prevMusic } from "../../store/musicPlayerReducer";
 
 function Controls({ play, pause, changeVolume }) {
   const playing = useSelector((state) => state.playing);
-
+  const dispatch = useDispatch();
   const onClickPlay = () => {
     play();
   };
@@ -25,11 +26,22 @@ function Controls({ play, pause, changeVolume }) {
     changeVolume(event.target.value);
   };
 
+  const onClickPrevious = () => {
+    dispatch(prevMusic());
+  };
+
+  const onClickNext = () => {
+    dispatch(nextMusic());
+  };
+
   return (
     <div className="control-area">
       <QueueMusic sx={{ fontSize: 30, cursor: "pointer" }} />
       <Repeat sx={{ fontSize: 30, cursor: "pointer" }} />
-      <SkipPrevious sx={{ fontSize: 30, cursor: "pointer" }} />
+      <SkipPrevious
+        sx={{ fontSize: 30, cursor: "pointer" }}
+        onClick={onClickPrevious}
+      />
       {playing ? (
         <Pause
           sx={{ fontSize: 30, cursor: "pointer" }}
@@ -41,7 +53,10 @@ function Controls({ play, pause, changeVolume }) {
           onClick={onClickPlay}
         />
       )}
-      <SkipNext sx={{ fontSize: 30, cursor: "pointer" }} />
+      <SkipNext
+        sx={{ fontSize: 30, cursor: "pointer" }}
+        onClick={onClickNext}
+      />
       <div className="volume-container">
         <VolumeUp sx={{ fontSize: 20 }} />
         <input

--- a/src/components/ProgressBar/ProgressBar.jsx
+++ b/src/components/ProgressBar/ProgressBar.jsx
@@ -5,9 +5,12 @@ import React, {
   useState,
 } from "react";
 import "./ProgressBar.scss";
-import music1 from "../../music/music-1.mp3";
-import { useDispatch } from "react-redux";
-import { playMusic, stopMusic } from "../../store/musicPlayerReducer";
+import { shallowEqual, useDispatch, useSelector } from "react-redux";
+import {
+  nextMusic,
+  playMusic,
+  stopMusic,
+} from "../../store/musicPlayerReducer";
 
 function ProgressBar(props, ref) {
   const audio = useRef();
@@ -15,6 +18,13 @@ function ProgressBar(props, ref) {
   const dispatch = useDispatch();
   const [currentTime, setcurrentTime] = useState("00:00");
   const [duration, setDuration] = useState("00:00");
+  const { playList, currentIndex } = useSelector(
+    (state) => ({
+      playList: state.playList,
+      currentIndex: state.currentIndex,
+    }),
+    shallowEqual
+  );
 
   useImperativeHandle(ref, () => ({
     play: () => {
@@ -58,13 +68,18 @@ function ProgressBar(props, ref) {
   const onPause = () => {
     dispatch(stopMusic());
   };
+
+  const onEnded = () => {
+    dispatch(nextMusic());
+  };
   return (
     <div className="progress-area" onMouseDown={onClickProgress}>
       <div className="progress-bar" ref={progressBar}>
         <audio
           autoPlay
+          onEnded={onEnded}
           ref={audio}
-          src={music1}
+          src={playList[currentIndex].music}
           onPlay={onPlay}
           onPause={onPause}
           onTimeUpdate={onTimeUpdate}

--- a/src/components/SongDetail/SongDetail.jsx
+++ b/src/components/SongDetail/SongDetail.jsx
@@ -1,21 +1,25 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import img1 from "../../images/music-1.jpg";
 import "./SongDetail.scss";
 
 function SongDetail() {
   const playing = useSelector((state) => state.playing);
+  const playList = useSelector((state) => state.playList);
+  const currentIndex = useSelector((state) => state.currentIndex);
   return (
     <>
       <div className="header">
         <span>{playing ? "Now Playing" : "Not Plyaing"}</span>
       </div>
       <div className="img-area">
-        <img src={img1} alt="이미지1"></img>
+        <img
+          src={playList[currentIndex].img}
+          alt={playList[currentIndex].name}
+        ></img>
       </div>
       <div className="music-info">
-        <p className="song">멋있는 음악제목</p>
-        <p className="artist">아티스트</p>
+        <p className="song">{playList[currentIndex].name}</p>
+        <p className="artist">{playList[currentIndex].artist}</p>
       </div>
     </>
   );

--- a/src/store/musicPlayerReducer.js
+++ b/src/store/musicPlayerReducer.js
@@ -59,10 +59,14 @@ const initialState = {
 //액션 타입 생성
 const PLAY_MUSIC = "musicPlayer/PLAY_MUSIC";
 const STOP_MUSIC = "musicPlayer/STOP_MUSIC";
+const NEXT_MUSIC = "musicPlayer/NEXT_MUSIC";
+const PREV_MUSIC = "musicPlayer/PREV_MUSIC";
 
 //액션 크리에이터
 export const playMusic = () => ({ type: PLAY_MUSIC });
 export const stopMusic = () => ({ type: STOP_MUSIC });
+export const nextMusic = () => ({ type: NEXT_MUSIC });
+export const prevMusic = () => ({ type: PREV_MUSIC });
 
 //리듀서
 export default function musicPlayerReducer(state = initialState, action) {
@@ -76,6 +80,22 @@ export default function musicPlayerReducer(state = initialState, action) {
       return {
         ...state,
         playing: false,
+      };
+    case NEXT_MUSIC:
+      const nextIndex = (state.currentIndex + 1) % state.playList.length;
+      return {
+        ...state,
+        currentIndex: nextIndex,
+        currentMusicId: state.playList[nextIndex].id,
+      };
+    case PREV_MUSIC:
+      const prevIndex =
+        (state.currentIndex - 1 + state.playList.length) %
+        state.playList.length;
+      return {
+        ...state,
+        currentIndex: prevIndex,
+        currentMusicId: state.playList[prevIndex].id,
       };
     default:
       return state;


### PR DESCRIPTION
music player에 이전 곡, 다음 곡으로 스킵하는 기능을 구현함.

* 기능 구현을 위해 reducer에 액션 타입, 크리에이터, 리듀서 내용을 추가
   * `NEXT_MUSIC` 의 경우 `nextIndex`의 값을 현재 인덱스에 1을 더한 값을 `PlayList`의 총 길이만큼 나눈 값으로 정의
   * `PREV_MUSIC` 의 경우 `prevINdex`의 값을 현재 인덱스에 1을 뺀 값에서 `PlayList`의 총 길이를 더한 값을 `PlayerList`의 총 길이로 나눈 값으로 정의 
* `Control` 컴포넌트에서 `useDispatch`를 이용하여 아이콘에 `onClick`이벤트를 추가
* `ProgressBar` 컴포넌트에 `useSelector`를 이용하여 고정값으로 정해놓은 음악 파일대신  `PlayList`의 현재 인덱스에 해당하는 음악이 재생되게 변경
* `audio`에 `onEnded`를 `useDispatch`를 이용하여 다음곡으로 이동하는`nextMusic()`을 호출하여 자동으로 다음 음악이 재생되게 함
* `SongDetail` 컴포넌트에 `useSelector`를 이용하여 음악이 재생되는 동안 해당 음악,아티스트,앨범 이미지가 렌더링되게 수정함.
This closes #13 