### PR TITLE
반복모드 아이콘 변경 기능 구현 및 랜덤 기능 구현

### DIFF
--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -5,14 +5,41 @@ import Pause from "@mui/icons-material/Pause";
 import PlayArrow from "@mui/icons-material/PlayArrow";
 import SkipPrevious from "@mui/icons-material/SkipPrevious";
 import SkipNext from "@mui/icons-material/SkipNext";
+import ShuffleIcon from "@mui/icons-material/Shuffle";
+import RepeatOneIcon from "@mui/icons-material/RepeatOne";
 import VolumeUp from "@mui/icons-material/VolumeUp";
 
 import "./Controls.scss";
 import { useDispatch, useSelector } from "react-redux";
-import { nextMusic, prevMusic } from "../../store/musicPlayerReducer";
+import {
+  nextMusic,
+  prevMusic,
+  setRepeat,
+} from "../../store/musicPlayerReducer";
+
+const RepeatButton = ({ repeat, ...props }) => {
+  switch (repeat) {
+    case "ALL":
+      return <Repeat sx={{ fontSize: 30, cursor: "pointer" }} {...props} />;
+
+    case "ONE":
+      return (
+        <RepeatOneIcon sx={{ fontSize: 30, cursor: "pointer" }} {...props} />
+      );
+
+    case "SHUFFLE":
+      return (
+        <ShuffleIcon sx={{ fontSize: 30, cursor: "pointer" }} {...props} />
+      );
+
+    default:
+      return null;
+  }
+};
 
 function Controls({ play, pause, changeVolume }) {
   const playing = useSelector((state) => state.playing);
+  const repeat = useSelector((state) => state.repeat);
   const dispatch = useDispatch();
   const onClickPlay = () => {
     play();
@@ -34,10 +61,16 @@ function Controls({ play, pause, changeVolume }) {
     dispatch(nextMusic());
   };
 
+  const onClickRepeat = () => {
+    dispatch(setRepeat());
+  };
+
   return (
     <div className="control-area">
       <QueueMusic sx={{ fontSize: 30, cursor: "pointer" }} />
-      <Repeat sx={{ fontSize: 30, cursor: "pointer" }} />
+
+      <RepeatButton repeat={repeat} onClick={onClickRepeat} />
+
       <SkipPrevious
         sx={{ fontSize: 30, cursor: "pointer" }}
         onClick={onClickPrevious}

--- a/src/store/musicPlayerReducer.js
+++ b/src/store/musicPlayerReducer.js
@@ -61,12 +61,22 @@ const PLAY_MUSIC = "musicPlayer/PLAY_MUSIC";
 const STOP_MUSIC = "musicPlayer/STOP_MUSIC";
 const NEXT_MUSIC = "musicPlayer/NEXT_MUSIC";
 const PREV_MUSIC = "musicPlayer/PREV_MUSIC";
+const SET_REPEAT = "musicPlayer/SET_REPEAT";
 
 //액션 크리에이터
+const repeatMode = ["ONE", "ALL", "SHUFFLE"];
 export const playMusic = () => ({ type: PLAY_MUSIC });
 export const stopMusic = () => ({ type: STOP_MUSIC });
 export const nextMusic = () => ({ type: NEXT_MUSIC });
 export const prevMusic = () => ({ type: PREV_MUSIC });
+export const setRepeat = () => ({ type: SET_REPEAT });
+
+const getRandomNum = (arr, excludeNum) => {
+  const randomNumber = Math.floor(Math.random() * arr.length);
+  return arr[randomNumber] === excludeNum
+    ? getRandomNum(arr, excludeNum)
+    : arr[randomNumber];
+};
 
 //리듀서
 export default function musicPlayerReducer(state = initialState, action) {
@@ -82,7 +92,13 @@ export default function musicPlayerReducer(state = initialState, action) {
         playing: false,
       };
     case NEXT_MUSIC:
-      const nextIndex = (state.currentIndex + 1) % state.playList.length;
+      const nextIndex =
+        state.repeat === "SHUFFLE"
+          ? getRandomNum(
+              Array.from(Array(playList.length).keys()),
+              state.currentIndex
+            )
+          : (state.currentIndex + 1) % state.playList.length;
       return {
         ...state,
         currentIndex: nextIndex,
@@ -90,12 +106,25 @@ export default function musicPlayerReducer(state = initialState, action) {
       };
     case PREV_MUSIC:
       const prevIndex =
-        (state.currentIndex - 1 + state.playList.length) %
-        state.playList.length;
+        state.repeat === "SHUFFLE"
+          ? getRandomNum(
+              Array.from(Array(playList.length).keys()),
+              state.currentIndex
+            )
+          : (state.currentIndex - 1 + state.playList.length) %
+            state.playList.length;
       return {
         ...state,
         currentIndex: prevIndex,
         currentMusicId: state.playList[prevIndex].id,
+      };
+    case SET_REPEAT:
+      return {
+        ...state,
+        repeat:
+          repeatMode[
+            (repeatMode.indexOf(state.repeat) + 1) % repeatMode.length
+          ],
       };
     default:
       return state;


### PR DESCRIPTION
반복모드 아이콘 변경 기능 구현 

* `musicPlayerReducer`에  repeatMode 종류를 리스트로 작성한 `repeatMode`와  repeatMode를 변경하는 액션을 생성하는 `setRepeat`를 생성함

* 리듀서에서 SET_REPEAT일 경우에 repeat의 값을 `repeatMode`리스트의 현재 repeat값의 인덱스에 1을 더한 뒤 , `repeatMode`의 총 길이로 나눈 값의 인덱스에 해당하는 repeatMode로 변경하는 방식이다. 

*  `Control`컴포넌트에 한곡 반복 Icon 과 랜덤 재생 Icon을 추가한뒤 repeat의 값에 따라 다른 아이콘을 보여주는 `RepeatButton`컴포넌트를 생성함

*  repeat 값은 `useSelector`를 이용하여 state에서 가져온 repeat값으로  `RepeatButton`에 onClick으로 `onClickRepeat` 메서드를 통해 repeat 값이 변경되게 함

* `RepeatButton`은 `useDispatch`통해서 리듀서의 액션 생성함수인 setRepeat를 호출함

랜덤 기능 구현

* 무작위 인덱스를 결정하기 위해서,  일련의 숫자를 제외한 나머지중 무작위의 인덱스에 속한 값을 리턴해주는 `getRandomNum`을 작성함. 만약 리턴되는 값이 제외하는 숫자와 일치한 경우 다른 값이 나올 때 까지 호출됨

* 리듀서의 `NEXT_MUSIC`, `PREV_MUSIC` case에서 각각 다음, 이전의 인덱스 값을 정의하는 구간에 `getRandomNum`을 사용해서 현재 재생되는 음악의 인덱스 값을 제외한 나머지 데이터들의 인덱스중 하나를 고르게 함.

This closes #15 