### PR TITLE
한곡 반복 재생 기능 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,12 +15,20 @@ function App() {
   const changeVolume = (volume) => {
     audioRef.current.changeVolume(volume);
   };
+  const resetDuration = () => {
+    audioRef.current.resetDuration();
+  };
   return (
     <div className="App">
       <div className="container">
         <SongDetail />
         <ProgressBar ref={audioRef} />
-        <Controls play={onPlay} pause={onPause} changeVolume={changeVolume} />
+        <Controls
+          play={onPlay}
+          pause={onPause}
+          changeVolume={changeVolume}
+          resetDuration={resetDuration}
+        />
         <PlayList />
       </div>
     </div>

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -37,7 +37,7 @@ const RepeatButton = ({ repeat, ...props }) => {
   }
 };
 
-function Controls({ play, pause, changeVolume }) {
+function Controls({ play, pause, changeVolume, resetDuration }) {
   const playing = useSelector((state) => state.playing);
   const repeat = useSelector((state) => state.repeat);
   const dispatch = useDispatch();
@@ -54,11 +54,19 @@ function Controls({ play, pause, changeVolume }) {
   };
 
   const onClickPrevious = () => {
-    dispatch(prevMusic());
+    if (repeat === "ONE") {
+      resetDuration();
+    } else {
+      dispatch(prevMusic());
+    }
   };
 
   const onClickNext = () => {
-    dispatch(nextMusic());
+    if (repeat === "ONE") {
+      resetDuration();
+    } else {
+      dispatch(nextMusic());
+    }
   };
 
   const onClickRepeat = () => {

--- a/src/components/ProgressBar/ProgressBar.jsx
+++ b/src/components/ProgressBar/ProgressBar.jsx
@@ -1,5 +1,6 @@
 import React, {
   forwardRef,
+  useCallback,
   useImperativeHandle,
   useRef,
   useState,
@@ -18,10 +19,11 @@ function ProgressBar(props, ref) {
   const dispatch = useDispatch();
   const [currentTime, setcurrentTime] = useState("00:00");
   const [duration, setDuration] = useState("00:00");
-  const { playList, currentIndex } = useSelector(
+  const { playList, currentIndex, repeat } = useSelector(
     (state) => ({
       playList: state.playList,
       currentIndex: state.currentIndex,
+      repeat: state.repeat,
     }),
     shallowEqual
   );
@@ -35,6 +37,9 @@ function ProgressBar(props, ref) {
     },
     changeVolume: (volume) => {
       audio.current.volume = volume;
+    },
+    resetDuration: () => {
+      audio.current.currentTime = 0;
     },
   }));
 
@@ -69,9 +74,14 @@ function ProgressBar(props, ref) {
     dispatch(stopMusic());
   };
 
-  const onEnded = () => {
-    dispatch(nextMusic());
-  };
+  const onEnded = useCallback(() => {
+    if (repeat === "ONE") {
+      audio.current.currentTime = 0;
+      audio.current.play();
+    } else {
+      dispatch(nextMusic());
+    }
+  }, [repeat, dispatch]);
   return (
     <div className="progress-area" onMouseDown={onClickProgress}>
       <div className="progress-bar" ref={progressBar}>


### PR DESCRIPTION
* `useImperativeHandle`에  audio 컴포넌트의 `currentITime`의 값을 0 으로 바꾸는 `resetDuration` 를 작성

* App.js 의 `Control` 컴포넌트의 props에 `resetDuration`을 추가한뒤 `Control` 컴포넌트에서 `onClickPrevious` `onClickNext`에 "repeat 값이 ONE일 경우에는 `resetDuration`을 호출한다" 는 조건을 추가함

* 음악의 재생이 다 끝난 뒤에도 다시 같은 음악이 재생되어야 하므로 `ProgressBar`컴포넌트 내부  `audio`의 `onEnded`에서도 같은 조건을 부여함

* 각각의 과정에서 조건을 추가하는 곳에서 `useCallback`을 사용해서 `repeat`의 값을 최신으로 유지하게 만듦

This closes #17 