### PR TITLE
sortable 적용 및 곡 선택 기능 구현 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
+        "@jyc-coder/sortable": "^0.1.1",
         "@mui/icons-material": "^5.10.3",
         "@mui/material": "^5.10.4",
         "@reduxjs/toolkit": "^1.8.5",
@@ -3179,6 +3180,20 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@jyc-coder/sortable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jyc-coder/sortable/-/sortable-0.1.1.tgz",
+      "integrity": "sha512-tP211N1t6DUM9phnR6ZJC3ivoPuX6HTQnZr5nxxEDfq0oz6tNJhXgKr4lV1nhIznEXyJ13Rz2WPGZv+GVNgwBA==",
+      "dependencies": {
+        "@testing-library/jest-dom": "^5.16.5",
+        "@testing-library/react": "^13.4.0",
+        "@testing-library/user-event": "^13.5.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-scripts": "5.0.1",
+        "web-vitals": "^2.1.4"
       }
     },
     "node_modules/@leichtgewicht/ip-codec": {
@@ -21060,6 +21075,20 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@jyc-coder/sortable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jyc-coder/sortable/-/sortable-0.1.1.tgz",
+      "integrity": "sha512-tP211N1t6DUM9phnR6ZJC3ivoPuX6HTQnZr5nxxEDfq0oz6tNJhXgKr4lV1nhIznEXyJ13Rz2WPGZv+GVNgwBA==",
+      "requires": {
+        "@testing-library/jest-dom": "^5.16.5",
+        "@testing-library/react": "^13.4.0",
+        "@testing-library/user-event": "^13.5.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-scripts": "5.0.1",
+        "web-vitals": "^2.1.4"
       }
     },
     "@leichtgewicht/ip-codec": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
+    "@jyc-coder/sortable": "^0.1.1",
     "@mui/icons-material": "^5.10.3",
     "@mui/material": "^5.10.4",
     "@reduxjs/toolkit": "^1.8.5",

--- a/src/App.js
+++ b/src/App.js
@@ -3,9 +3,10 @@ import SongDetail from "./components/SongDetail/SongDetail";
 import ProgressBar from "./components/ProgressBar/ProgressBar";
 import Controls from "./components/Controls/Controls";
 import PlayList from "./components/PlayList/PlayList";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 function App() {
   const audioRef = useRef();
+  const [showPlayList, setshowPlayList] = useState(false);
   const onPlay = () => {
     audioRef.current.play();
   };
@@ -28,8 +29,12 @@ function App() {
           pause={onPause}
           changeVolume={changeVolume}
           resetDuration={resetDuration}
+          setshowPlayList={setshowPlayList}
         />
-        <PlayList />
+        <PlayList
+          showPlayList={showPlayList}
+          setshowPlayList={setshowPlayList}
+        />
       </div>
     </div>
   );

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -37,7 +37,13 @@ const RepeatButton = ({ repeat, ...props }) => {
   }
 };
 
-function Controls({ play, pause, changeVolume, resetDuration }) {
+function Controls({
+  play,
+  pause,
+  changeVolume,
+  resetDuration,
+  setshowPlayList,
+}) {
   const playing = useSelector((state) => state.playing);
   const repeat = useSelector((state) => state.repeat);
   const dispatch = useDispatch();
@@ -73,9 +79,16 @@ function Controls({ play, pause, changeVolume, resetDuration }) {
     dispatch(setRepeat());
   };
 
+  const onClickShowPlayList = () => {
+    setshowPlayList(true);
+  };
+
   return (
     <div className="control-area">
-      <QueueMusic sx={{ fontSize: 30, cursor: "pointer" }} />
+      <QueueMusic
+        sx={{ fontSize: 30, cursor: "pointer" }}
+        onClick={onClickShowPlayList}
+      />
 
       <RepeatButton repeat={repeat} onClick={onClickRepeat} />
 

--- a/src/components/PlayList/PlayList.jsx
+++ b/src/components/PlayList/PlayList.jsx
@@ -2,26 +2,43 @@ import React from "react";
 import classNames from "classnames";
 import { Close, QueueMusic } from "@mui/icons-material";
 import PlayListItem from "./PlayListItem";
-import MusicList from "../../store/data";
 import "./PlayList.scss";
+import SortableList from "@jyc-coder/sortable";
+import { useDispatch, useSelector } from "react-redux";
+import { setCurrentIndex } from "../../store/musicPlayerReducer";
 
-const PlayList = () => {
+const PlayList = ({ showPlayList, setshowPlayList }) => {
+  const playList = useSelector((state) => state.playList);
+  const dispatch = useDispatch();
+  const onClickClosePlayList = () => {
+    setshowPlayList(false);
+  };
+
+  const renderItem = (item, index) => (
+    <PlayListItem item={item} index={index} />
+  );
+
+  const onClickItem = (index) => {
+    dispatch(setCurrentIndex(index));
+  };
+
   return (
-    <div className={classNames("play-list")}>
+    <div className={classNames("play-list", { show: showPlayList })}>
       <div className="header">
         <div className="row">
           <QueueMusic className="list" />
           <span>Playlist</span>
         </div>
-        <Close sx={{ fontSize: 22, cursor: "pointer" }} />
+        <Close
+          sx={{ fontSize: 22, cursor: "pointer" }}
+          onClick={onClickClosePlayList}
+        />
       </div>
-      <ul>
-        {MusicList.map((item, index) => (
-          <li key={index}>
-            <PlayListItem item={item} index={index} />
-          </li>
-        ))}
-      </ul>
+      <SortableList
+        data={playList}
+        renderItem={renderItem}
+        onClickItem={onClickItem}
+      />
     </div>
   );
 };

--- a/src/components/PlayList/PlayListItem.jsx
+++ b/src/components/PlayList/PlayListItem.jsx
@@ -1,14 +1,22 @@
 import React from "react";
 import classNames from "classnames";
+import { useSelector } from "react-redux";
 
 const PlayListItem = ({ item, index }) => {
+  const currentIndex = useSelector((state) => state.currentIndex);
   return (
     <>
-      <div className={classNames("row")}>
+      <div className={classNames("row", { playing: currentIndex === index })}>
         <span>{item.name}</span>
         <p>{item.artist}</p>
       </div>
-      <span className={classNames("music-duration")}>00:00</span>
+      <span
+        className={classNames("music-duration", {
+          playing: currentIndex === index,
+        })}
+      >
+        00:00
+      </span>
     </>
   );
 };

--- a/src/store/musicPlayerReducer.js
+++ b/src/store/musicPlayerReducer.js
@@ -62,6 +62,7 @@ const STOP_MUSIC = "musicPlayer/STOP_MUSIC";
 const NEXT_MUSIC = "musicPlayer/NEXT_MUSIC";
 const PREV_MUSIC = "musicPlayer/PREV_MUSIC";
 const SET_REPEAT = "musicPlayer/SET_REPEAT";
+const SET_CURRENT_INDEX = "musicPlayer/SET_CURRENT_INDEX";
 
 //액션 크리에이터
 const repeatMode = ["ONE", "ALL", "SHUFFLE"];
@@ -70,6 +71,7 @@ export const stopMusic = () => ({ type: STOP_MUSIC });
 export const nextMusic = () => ({ type: NEXT_MUSIC });
 export const prevMusic = () => ({ type: PREV_MUSIC });
 export const setRepeat = () => ({ type: SET_REPEAT });
+export const setCurrentIndex = (index) => ({ type: SET_CURRENT_INDEX, index });
 
 const getRandomNum = (arr, excludeNum) => {
   const randomNumber = Math.floor(Math.random() * arr.length);
@@ -125,6 +127,12 @@ export default function musicPlayerReducer(state = initialState, action) {
           repeatMode[
             (repeatMode.indexOf(state.repeat) + 1) % repeatMode.length
           ],
+      };
+    case SET_CURRENT_INDEX:
+      return {
+        ...state,
+        currentIndex: action.index,
+        currentMusicId: state.playList[action.index].id,
       };
     default:
       return state;


### PR DESCRIPTION
* npm에 배포한 `sortable`패키지 설치
* 설치한 `sortable`패키지를 사용해서 `
PlayList`컴포넌트의 `MusicList`를 대신해서 `SortableList`를 작성함

* `Controls`컴포넌트의 `QueueMusic`아이콘을 클릭하면 리스트가 나타나게 하기 위해서 `onClick` prop을 추가함

* `PlayList`의  음악을 클릭하면 재생되도록 `SortableList`에 `onClickItem` prop을 추가함
클릭하면  `currentIndex`와 `currentMusicId`가 클릭한 음악의 index와 id값으로 변경됨

*`PlayListItem`에서 `useSelector`를 사용해서 가져온 `currentIndex`와 `PlayList`에서 `renderItem`으로 받아온 index를 비교해서 같은 경우에만 클래스에 `playing`이 붙게되어 이전에 설정한 스타일이 적용면서 녹색으로 변한다

This Close #19 